### PR TITLE
Update the firebase bigquery import script to allow for subcollections

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -34,7 +34,7 @@ const read = util.promisify(fs.readFile);
 const unlink = util.promisify(fs.unlink);
 
 const BIGQUERY_VALID_CHARACTERS = /^[a-zA-Z0-9_]+$/;
-const FIRESTORE_VALID_CHARACTERS = /^[^\/]+$/;
+const FIRESTORE_VALID_CHARACTERS = /^.+$/;
 
 const FIRESTORE_COLLECTION_NAME_MAX_CHARS = 6144;
 const BIGQUERY_RESOURCE_NAME_MAX_CHARS = 1024;
@@ -160,9 +160,10 @@ const run = async (): Promise<number> => {
   // operations supersede imports when listing the live documents.
   let cursor;
 
+  let sanitizedSourceCollectionPath = sourceCollectionPath.replace(/\//g, '_');
   let cursorPositionFile =
     __dirname +
-    `/from-${sourceCollectionPath}-to-${projectId}_${datasetId}_${rawChangeLogName}`;
+    `/from-${sanitizedSourceCollectionPath}-to-${projectId}_${datasetId}_${rawChangeLogName}`;
   if (await exists(cursorPositionFile)) {
     let cursorDocumentId = (await read(cursorPositionFile)).toString();
     cursor = await firebase


### PR DESCRIPTION
Notes: there could be a collision technically rare but possible. if you have a sub collection named `users/person/files` and you also had a top level collection named `users_person_files` they would collide on the saved index file locally. Also i loosened up the validation to allow `/` on both the project name and the collection name. so i could see them wanting to solve both of those